### PR TITLE
fix: editor validations with typescript files

### DIFF
--- a/e2e/files/typed.ts
+++ b/e2e/files/typed.ts
@@ -1,0 +1,5 @@
+type Args = {
+	param: string;
+};
+
+export const myFunction = (args: Args) => args;

--- a/e2e/upload-file.test.ts
+++ b/e2e/upload-file.test.ts
@@ -53,10 +53,134 @@ test.describe('Check tabs behavior', () => {
 		await expect(page.locator('[data-testid="file-uploader"]')).toHaveCount(1);
 	});
 
+	test(`Should transform typescript file with types`, async () => {
+		await uploadFile(`./files/typed.ts`, page);
+		await page.waitForSelector('[data-testid="swc-transform"] textarea');
+		const swcOutput = await page.inputValue(
+			'[data-testid="swc-transform"] textarea'
+		);
+		expect(swcOutput).toBe('export const myFunction = (args)=>args\n;\n');
+
+		await page.waitForSelector('[data-testid="babel-transform"] textarea');
+		const babelOutput = await page.inputValue(
+			'[data-testid="babel-transform"] textarea'
+		);
+		expect(babelOutput).toBe('export const myFunction = args => args;');
+	});
+
 	test('Should change tab title by the uploaded file', async () => {
 		await uploadFile(`./files/basic.tsx`, page);
 		const tabZero = await page.$('[data-testid^="tab-0"] p');
 		const tabZeroTitle = await tabZero.innerText();
 		expect(tabZeroTitle).toBe('basic.tsx');
+	});
+
+	test('Should set specific swc and babel config when is typescript file', async () => {
+		await uploadFile(`./files/basic.tsx`, page);
+		const swcConfigButton = await page.$(
+			'[data-testid="swc-transform"] button[data-testid="open-config"]'
+		);
+		await swcConfigButton.click();
+		await page.waitForSelector('[data-testid="config-editor"] textarea');
+		const swcConfig = await page.inputValue(
+			'[data-testid="config-editor"] textarea'
+		);
+
+		const closeModalButton = await page.$('button[aria-label="Close"]');
+		await closeModalButton.click();
+
+		const babelConfigButton = await page.$(
+			'[data-testid="babel-transform"] button[data-testid="open-config"]'
+		);
+		await babelConfigButton.click();
+		await page.waitForSelector('[data-testid="config-editor"] textarea');
+		const babelConfig = await page.inputValue(
+			'[data-testid="config-editor"] textarea'
+		);
+
+		expect(swcConfig).toBe(
+			JSON.stringify(
+				{
+					sourceMaps: false,
+					jsc: {
+						parser: {
+							syntax: 'typescript',
+							tsx: true,
+						},
+						target: 'es2022',
+					},
+				},
+				null,
+				2
+			)
+		);
+
+		expect(babelConfig).toBe(
+			JSON.stringify(
+				{
+					babelrc: false,
+					configFile: false,
+					ast: false,
+					presets: ['@babel/preset-react', '@babel/preset-typescript'],
+					filename: 'basic.tsx',
+				},
+				null,
+				2
+			)
+		);
+	});
+
+	test('Should set specific swc and babel config when is javascript file', async () => {
+		await uploadFile(`./files/basic.jsx`, page);
+		const swcConfigButton = await page.$(
+			'[data-testid="swc-transform"] button[data-testid="open-config"]'
+		);
+		await swcConfigButton.click();
+		await page.waitForSelector('[data-testid="config-editor"] textarea');
+		const swcConfig = await page.inputValue(
+			'[data-testid="config-editor"] textarea'
+		);
+
+		const closeModalButton = await page.$('button[aria-label="Close"]');
+		await closeModalButton.click();
+
+		const babelConfigButton = await page.$(
+			'[data-testid="babel-transform"] button[data-testid="open-config"]'
+		);
+		await babelConfigButton.click();
+		await page.waitForSelector('[data-testid="config-editor"] textarea');
+		const babelConfig = await page.inputValue(
+			'[data-testid="config-editor"] textarea'
+		);
+
+		expect(swcConfig).toBe(
+			JSON.stringify(
+				{
+					sourceMaps: false,
+					jsc: {
+						parser: {
+							syntax: 'ecmascript',
+							jsx: true,
+						},
+						target: 'es2022',
+					},
+				},
+				null,
+				2
+			)
+		);
+
+		expect(babelConfig).toBe(
+			JSON.stringify(
+				{
+					babelrc: false,
+					configFile: false,
+					ast: false,
+					presets: ['@babel/preset-react'],
+				},
+				null,
+				2
+			)
+		);
 	});
 });

--- a/packages/desktop-app/src/renderer/pages/home/SwcAndBabelComparer.tsx
+++ b/packages/desktop-app/src/renderer/pages/home/SwcAndBabelComparer.tsx
@@ -12,10 +12,14 @@ export const SwcAndBabelComparer = ({ tab }: SwcAndBabelComparerProps) => {
 	const { dispatch } = useViewerContext();
 
 	const onFileUpload = (event: ProgressEvent<FileReader>, file: File) => {
+		const fileExtension = file.name.split('.').pop();
+		const isTypeScriptFile = ['tsx', 'ts'].some((ext) => ext === fileExtension);
+
 		dispatch({
 			type: ViewerAction.UpdateFileTransform,
 			payload: {
 				tabId: tab.id,
+				isTypeScriptFile,
 				fileTransform: {
 					name: file.name,
 					path: file.path,

--- a/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/babelTransform/babelConfigForm/BabelConfigEditor.tsx
+++ b/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/babelTransform/babelConfigForm/BabelConfigEditor.tsx
@@ -33,7 +33,7 @@ export const BabelConfigEditor = ({ tab }: BabelConfigEditorProps) => {
 		helpers.setValue(value);
 	};
 
-	const filePath = `${tab.id}/.babelrc`;
+	const filePath = `/${tab.id}/.babelrc`;
 
 	return (
 		<>

--- a/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/shared/JsonConfigEditor.tsx
+++ b/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/shared/JsonConfigEditor.tsx
@@ -36,7 +36,12 @@ export const JsonConfigEditor = ({
 	}, [monaco, schema]);
 
 	useEffect(() => {
-		validateRef.current = () => monaco?.editor.getModelMarkers({});
+		validateRef.current = () => {
+			const model = monaco?.editor
+				.getModels()
+				.find((model) => model.uri.path === path);
+			return monaco?.editor.getModelMarkers({ resource: model?.uri });
+		};
 	}, [validateRef, monaco]);
 
 	return (

--- a/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/swcTransform/swcConfigForm/SwcConfigEditor.tsx
+++ b/packages/desktop-app/src/renderer/pages/home/swcAndBabelComparer/transformer/swcTransform/swcConfigForm/SwcConfigEditor.tsx
@@ -24,6 +24,7 @@ export const SwcConfigEditor = ({ tab }: SwcConfigEditorProps) => {
 		name: 'config',
 		validate: (value: string) => {
 			return new Promise((resolve) => {
+				console.log({ validation: validateEditor.current() });
 				// This is done to avoid async validation of monaco-editor
 				setTimeout(async () => {
 					const validations = validateEditor.current();
@@ -85,7 +86,7 @@ export const SwcConfigEditor = ({ tab }: SwcConfigEditorProps) => {
 		helpers.setValue(value);
 	};
 
-	const filePath = `${tab.id}/.swcrc`;
+	const filePath = `/${tab.id}/.swcrc`;
 
 	return (
 		<>


### PR DESCRIPTION
Fixes: https://github.com/IvanRodriCalleja/swc-viewer/issues/36

- Control scoped editor validations
- Set correct configuration (javascript or typescript) depending on file type